### PR TITLE
Removed opt command and added functionality for helper pin/unpin and context menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ dmypy.json
 .pyre/
 
 config.json
+config.toml

--- a/cogs/helper.py
+++ b/cogs/helper.py
@@ -1,40 +1,89 @@
 import discord
 from discord.ext import commands
+from utils.config import subjects 
 
 
 class Helper(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
-        self.bot = bot
-
+        self.bot = bot        
+        self.subjects_list = [pair.split(",") for pair in subjects.split(";")]
+        self.subject_channels_list = [int(pair[0]) for pair in self.subjects_list]
+        
+        @bot.tree.context_menu(name="Toggle Pin")
+        async def pin_message(interaction: discord.Interaction, message: discord.Message):
+            # checks if the command is being issued in a subject channel
+            if interaction.channel.id not in self.subject_channels_list:
+                return await interaction.response.send_message('You may only pin messages in subject channels')
+            # checks if the person issuing the action is a helper
+            subject_helper_role  = [int(list[1]) for list in self.subjects_list if str(interaction.channel.id) in list][0]
+            if subject_helper_role not in [role.id for role in interaction.user.roles]:
+                return await interaction.response.send_message('Only subject helpers can pin/unpin messages')
+            # unpins the message if pinned already
+            if message.pinned:
+                await message.unpin()
+                return await interaction.response.send_message('The message was successfully unpinned')
+            # pins the message if not the case
+            else:
+                await message.pin()
+                await interaction.response.send_message('The message was successfully pinned')        
+                
     @commands.Cog.listener()
     async def on_member_update(self, before: discord.Member, after: discord.Member):
         """
         Update helper message based on user helper/dehelper.
         """
         ...
-
-    
+        
+            
     @commands.hybrid_command()
     async def helpermessage(self, ctx: commands.Context):
         """
         Send an updating list of helpers for a subject.
         """ 
         raise NotImplementedError('Command requires implementation and permission set-up.')
-    
+     
     @commands.hybrid_command()
-    async def pin(self, ctx: commands.Context):
+    async def pin(self, ctx: commands.Context, message):
         """
         Pin a message to a channel.
-        """ 
-        raise NotImplementedError('Command requires implementation and permission set-up.')
-    
+        """
+        if ctx.channel.id not in self.subject_channels_list:
+            return await ctx.send('You may only pin messages in subject channels')
+        subject_helper_role  = [int(list[1]) for list in self.subjects_list if str(ctx.channel.id) in list][0]
+        if subject_helper_role not in [role.id for role in ctx.author.roles]:
+            return await ctx.send('Only subject helpers can pin messages')
+        # ensure that a valid message is referenced
+        try:
+            message = await ctx.channel.fetch_message(message)
+        # checks if the message is already pinned
+            if message.pinned:
+                return await ctx.send('The message is already pinned.')
+        # pins the message
+            await message.pin()
+            return await ctx.send('The message was successfully pinned')
+        except discord.NotFound:
+            return await ctx.send('Invalid message ID provided. You must be in the same channel as the message.')
+            
     @commands.hybrid_command()
-    async def unpin(self, ctx: commands.Context):
+    async def unpin(self, ctx: commands.Context, message):
         """
         Unpin a message from a channel.
-        """ 
-        raise NotImplementedError('Command requires implementation and permission set-up.')
-
-
+        """
+        if ctx.channel.id not in self.subject_channels_list:
+            return await ctx.send('You may only unpin messages in subject channels')
+        subject_helper_role  = [int(list[1]) for list in self.subjects_list if str(ctx.channel.id) in list][0]
+        if subject_helper_role not in [role.id for role in ctx.author.roles]:
+            return await ctx.send('Only subject helpers can pin messages')
+        try:
+            message = await ctx.channel.fetch_message(message)
+        # checks if the message is already unpinned
+            if not message.pinned:
+                return await ctx.send('The message is already unpinned')
+        # unpins the message
+            await message.unpin()
+            return await ctx.send('The message was successfully unpinned')
+        except discord.NotFound:
+            return await ctx.send('Invalid message ID provided. You must be in the same channel as the message')
+ 
 async def setup(bot: commands.Bot):
     await bot.add_cog(Helper(bot))

--- a/cogs/helper.py
+++ b/cogs/helper.py
@@ -6,35 +6,41 @@ from utils.config import subjects
 class Helper(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot        
-        self.subjects_list = [pair.split(",") for pair in subjects.split(";")]
-        self.subject_channels_list = [int(pair[0]) for pair in self.subjects_list]
+        self.pairs = subjects.split(';')
+        self.subjects = {int(pair.split(',')[0]):int(pair.split(',')[1]) for pair in self.pairs}
         
         @bot.tree.context_menu(name="Toggle Pin")
         async def pin_message(interaction: discord.Interaction, message: discord.Message):
-            # checks if the command is being issued in a subject channel
-            if interaction.channel.id not in self.subject_channels_list:
-                return await interaction.response.send_message('You may only pin messages in subject channels')
             # checks if the person issuing the action is a helper
-            subject_helper_role  = [int(list[1]) for list in self.subjects_list if str(interaction.channel.id) in list][0]
-            if subject_helper_role not in [role.id for role in interaction.user.roles]:
-                return await interaction.response.send_message('Only subject helpers can pin/unpin messages')
-            # unpins the message if pinned already
-            if message.pinned:
-                await message.unpin()
-                return await interaction.response.send_message('The message was successfully unpinned')
-            # pins the message if not the case
-            else:
-                await message.pin()
-                await interaction.response.send_message('The message was successfully pinned')        
+            helper_role_id = self.subjects[interaction.channel.id]
+            if not any(helper_role_id == role.id for role in interaction.user.roles):
+                return await interaction.response.send_message('Only subject helpers can pin/unpin messages.', ephemeral=True)
+            # checks if the command is being issued in a subject channel
+            if interaction.channel.id not in self.subjects.keys():
+                return await interaction.response.send_message('You may only pin messages in subject channels.', ephemeral=True)
+            try:
+                if message.pinned:
+                    await message.unpin()
+                    return await interaction.response.send_message('The message was successfully unpinned')
+                else:
+                    await message.pin()
+                    return await interaction.response.send_message('The message was successfully pinned')
+            except discord.Forbidden:
+                return await interaction.response.send_message('The bot does not have permission to pin/unpin messages.', ephemeral=True)
+            except discord.NotFound:
+                return await interaction.response.send_message('Invalid message ID provided.', ephemeral=True)
+            except discord.HTTPException:
+                if not message.pinned:
+                    return await interaction.response.send_message('You have reached the maximum number of pins for this channel.', ephemeral=True)
+                else:
+                    return await interaction.response.send_message('The message could not be unpinned', ephemeral=True)
                 
     @commands.Cog.listener()
     async def on_member_update(self, before: discord.Member, after: discord.Member):
         """
         Update helper message based on user helper/dehelper.
         """
-        ...
-        
-            
+        ...    
     @commands.hybrid_command()
     async def helpermessage(self, ctx: commands.Context):
         """
@@ -43,47 +49,52 @@ class Helper(commands.Cog):
         raise NotImplementedError('Command requires implementation and permission set-up.')
      
     @commands.hybrid_command()
-    async def pin(self, ctx: commands.Context, message):
+    async def pin(self, ctx: commands.Context, message: discord.Message):
         """
         Pin a message to a channel.
         """
-        if ctx.channel.id not in self.subject_channels_list:
-            return await ctx.send('You may only pin messages in subject channels')
-        subject_helper_role  = [int(list[1]) for list in self.subjects_list if str(ctx.channel.id) in list][0]
-        if subject_helper_role not in [role.id for role in ctx.author.roles]:
+        helper_role_id = self.subjects[ctx.channel.id]
+        if not any(helper_role_id == role.id for role in ctx.author.roles):
             return await ctx.send('Only subject helpers can pin messages')
-        # ensure that a valid message is referenced
-        try:
-            message = await ctx.channel.fetch_message(message)
+        if ctx.channel.id not in self.subjects.keys():
+            return await ctx.send('You may only pin messages in subject channels.')
         # checks if the message is already pinned
-            if message.pinned:
-                return await ctx.send('The message is already pinned.')
+        if message.pinned:
+            return await ctx.send('The message is already pinned.')
         # pins the message
+        try:
             await message.pin()
-            return await ctx.send('The message was successfully pinned')
+            await ctx.send('The message was successfully pinned.')
+        except discord.Forbidden:
+            return await ctx.send('The bot does not have the permission to unpin messages.')
         except discord.NotFound:
-            return await ctx.send('Invalid message ID provided. You must be in the same channel as the message.')
+             return await ctx.send('The message was not found.')
+        except discord.HTTPException:
+             return await ctx.send('You have reached the maximum number of pins for this channel.')
             
     @commands.hybrid_command()
-    async def unpin(self, ctx: commands.Context, message):
+    async def unpin(self, ctx: commands.Context, message: discord.Message):
         """
         Unpin a message from a channel.
         """
-        if ctx.channel.id not in self.subject_channels_list:
-            return await ctx.send('You may only unpin messages in subject channels')
-        subject_helper_role  = [int(list[1]) for list in self.subjects_list if str(ctx.channel.id) in list][0]
-        if subject_helper_role not in [role.id for role in ctx.author.roles]:
-            return await ctx.send('Only subject helpers can pin messages')
-        try:
-            message = await ctx.channel.fetch_message(message)
+        helper_role_id = self.subjects[ctx.channel.id]
+        if helper_role_id not in [role.id for role in ctx.author.roles]:
+            return await ctx.send('Only subject helpers can unpin messages.')
+        if ctx.channel.id not in self.subjects.keys():
+            return await ctx.send('You may only unpin messages in subject channels.')
         # checks if the message is already unpinned
-            if not message.pinned:
-                return await ctx.send('The message is already unpinned')
+        if not message.pinned:
+            return await ctx.send('The message is already unpinned.')
         # unpins the message
+        try:
             await message.unpin()
-            return await ctx.send('The message was successfully unpinned')
+            return await ctx.send('The message was successfully unpinned.')
+        except discord.Forbidden:
+            return await ctx.send('The bot does not have the permission to unpin messages.')
         except discord.NotFound:
-            return await ctx.send('Invalid message ID provided. You must be in the same channel as the message')
+             return await interaction.response.send_message('Invalid message ID provided.')
+        except discord.HTTPException:
+             return await interaction.response.send_message('The message could not be unpinned.')
  
 async def setup(bot: commands.Bot):
     await bot.add_cog(Helper(bot))

--- a/cogs/helper.py
+++ b/cogs/helper.py
@@ -6,8 +6,7 @@ from utils.config import subjects
 class Helper(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot        
-        self.pairs = subjects.split(';')
-        self.subjects = {int(pair.split(',')[0]):int(pair.split(',')[1]) for pair in self.pairs}
+        self.subjects = dict(map(int, pair.split(',')) for pair in subjects.split(';'))
         
         @bot.tree.context_menu(name="Toggle Pin")
         async def pin_message(interaction: discord.Interaction, message: discord.Message):

--- a/cogs/helper.py
+++ b/cogs/helper.py
@@ -68,7 +68,7 @@ class Helper(commands.Cog):
         except discord.Forbidden:
             return await ctx.send('The bot does not have the permission to unpin messages.')
         except discord.NotFound:
-             return await ctx.send('The message was not found.')
+             return await ctx.send('Invalid message ID provided.')
         except discord.HTTPException:
              return await ctx.send('You have reached the maximum number of pins for this channel.')
             

--- a/cogs/helper.py
+++ b/cogs/helper.py
@@ -49,10 +49,12 @@ class Helper(commands.Cog):
         raise NotImplementedError('Command requires implementation and permission set-up.')
      
     @commands.hybrid_command()
-    async def pin(self, ctx: commands.Context, message: discord.Message):
+    async def pin(self, ctx: commands.Context, message: discord.Message = None):
         """
         Pin a message to a channel.
         """
+        if message is None:
+            return await ctx.send("Please provide a message to pin.")
         helper_role_id = self.subjects[ctx.channel.id]
         if not any(helper_role_id == role.id for role in ctx.author.roles):
             return await ctx.send('Only subject helpers can pin messages')
@@ -73,10 +75,12 @@ class Helper(commands.Cog):
              return await ctx.send('You have reached the maximum number of pins for this channel.')
             
     @commands.hybrid_command()
-    async def unpin(self, ctx: commands.Context, message: discord.Message):
+    async def unpin(self, ctx: commands.Context, message: discord.Message = None):
         """
         Unpin a message from a channel.
         """
+        if message is None:
+            return await ctx.send("Please provide a message to unpin.")
         helper_role_id = self.subjects[ctx.channel.id]
         if helper_role_id not in [role.id for role in ctx.author.roles]:
             return await ctx.send('Only subject helpers can unpin messages.')
@@ -92,9 +96,9 @@ class Helper(commands.Cog):
         except discord.Forbidden:
             return await ctx.send('The bot does not have the permission to unpin messages.')
         except discord.NotFound:
-             return await interaction.response.send_message('Invalid message ID provided.')
+             return await ctx.send('Invalid message ID provided.')
         except discord.HTTPException:
-             return await interaction.response.send_message('The message could not be unpinned.')
+             return await ctx.send('The message could not be unpinned.')
  
 async def setup(bot: commands.Bot):
     await bot.add_cog(Helper(bot))

--- a/cogs/public.py
+++ b/cogs/public.py
@@ -57,14 +57,7 @@ class Public(commands.Cog):
         embed.set_author(name=f"{user.name}'s banner", icon_url=user.display_avatar.url)
         embed.set_image(url=user.banner.url)
         await ctx.send(embed=embed)
-    
-    @commands.hybrid_command()
-    async def opt(self, ctx: commands.Context):
-        """
-        Toggle user's access to a channel.
-        """ 
-        raise NotImplementedError('Command requires implementation and permission set-up.')
-    
+ 
     @commands.hybrid_command()
     async def ping(self, ctx: commands.Context):
         """

--- a/utils/config.py
+++ b/utils/config.py
@@ -14,4 +14,3 @@ db_host        = os.getenv("DB_HOST")        if "DB_HOST"        in os.environ e
 db_user        = os.getenv("DB_USER")        if "DB_USER"        in os.environ else _config['db_user']
 db_name        = os.getenv("DB_NAME")        if "DB_NAME"        in os.environ else _config['db_name']
 db_password    = os.getenv("DB_PASSWORD")    if "DB_PASSWORD"    in os.environ else _config['db_password']
-subjects       = os.getenv("SUBJECTS")       if "SUBJECTS"       in os.environ else _config['subjects']

--- a/utils/config.py
+++ b/utils/config.py
@@ -14,3 +14,4 @@ db_host        = os.getenv("DB_HOST")        if "DB_HOST"        in os.environ e
 db_user        = os.getenv("DB_USER")        if "DB_USER"        in os.environ else _config['db_user']
 db_name        = os.getenv("DB_NAME")        if "DB_NAME"        in os.environ else _config['db_name']
 db_password    = os.getenv("DB_PASSWORD")    if "DB_PASSWORD"    in os.environ else _config['db_password']
+subjects       = os.getenv("SUBJECTS")       if "SUBJECTS"       in os.environ else _config['subjects']


### PR DESCRIPTION
Reason for removal of Opt command: First brought up by Kallak and on further discussion with other developers, it was decided to remove it due to bloat as well as the presence of the 'browse channels' feature which does the same thing.

The pin and unpin commands work as expected, along with the 'Toggle pin' command which shows up after right clicking on the desired message -> apps thus pinning the message if pinned and unpinning the message if unpinned.