### PR TITLE
Black autoformatting + pre-commit

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -6,11 +6,17 @@ jobs:
   isort:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: isort/isort-action@v1
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: psf/black@stable
 
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: astral-sh/ruff-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,6 @@ config.toml
 !example.env
 !src/**/config.toml
 
-# PDM files
-.pdm-python
-
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ config.toml
 !example.env
 !src/**/config.toml
 
+# PDM files
+.pdm-python
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-toml
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+
+  - repo: https://github.com/pycqa/isort
+    rev: 7.0.0
+    hooks:
+      - id: isort
+        name: isort (python)
+
+  - repo: https://github.com/psf/black
+    rev: 25.12.0
+    hooks:
+      - id: black
+        language_version: python3
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.10
+    hooks:
+      - id: ruff-check
+        args: [--fix]
+      - id: ruff-format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,11 +59,22 @@ docker-compose -f docker-compose.postgres.yml up --build
 
 Once the bot is up and running, you are ready to start developing!
 
-6. Checking codestyle
+6. Enforcing codestyle
 
-Before you push changes, ensure that your code aligns with the codestyle for this project. To run [ruff](https://docs.astral.sh/ruff/) or [isort](https://pycqa.github.io/isort/index.html), use the following commands:
+This project uses [pre-commit](https://pre-commit.com/) to enforce codestyle with every commit.
+Codestyle is enforced with [isort](https://pycqa.github.io/isort/index.html) and [black](https://black.readthedocs.io/en/stable/) (and checked by [ruff](https://docs.astral.sh/ruff/)), along with other usual pre-commit hooks.
+See `.pre-commit-config.yaml` for all the details.
+
+Before you push changes, ensure that you [install pre-commit](https://pre-commit.com/#install) and run the `install` command in the root directory:
 
 ```
-uv run ruff check .
+pre-commit install
+```
+
+You can also run any of the codestyle checks or autoformatters on the codebase individually via `uv`:
+
+```
 uv run isort .
+uv run black .
+uv run ruff check .
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ build-backend = "uv_build"
 
 [dependency-groups]
 dev = [
+    "black>=25.12.0",
     "isort>=7.0.0",
     "pytest>=9.0.0",
     "pytest-asyncio>=1.3.0",

--- a/src/ib_py/cogs/guildconfig.py
+++ b/src/ib_py/cogs/guildconfig.py
@@ -16,78 +16,60 @@ config.requires("prefix")
 logger = logging.getLogger(__name__)
 
 MENTION_STYLES = {
-    'TextChannel': '#',
-    'Role': '@&',
+    "TextChannel": "#",
+    "Role": "@&",
 }
 
 GUILD_CONFIGURATION_DATA = {
-    'modlog': {
-        'datatype': 'TextChannel',
-        'dataname': 'modlog_id',
-        'desc': 'Set a public moderation log channel.'
+    "modlog": {
+        "datatype": "TextChannel",
+        "dataname": "modlog_id",
+        "desc": "Set a public moderation log channel.",
     },
-    'staffmodlog': {
-        'datatype': 'TextChannel',
-        'dataname': 'modlog_staff_id',
-        'desc': 'Set a staff moderation log channel.'
+    "staffmodlog": {
+        "datatype": "TextChannel",
+        "dataname": "modlog_staff_id",
+        "desc": "Set a staff moderation log channel.",
     },
-    'updates': {
-        'datatype': 'TextChannel',
-        'dataname': 'updates_id',
-        'desc': 'Set an updates channel.'
+    "updates": {
+        "datatype": "TextChannel",
+        "dataname": "updates_id",
+        "desc": "Set an updates channel.",
     },
-    'logs': {
-        'datatype': 'TextChannel',
-        'dataname': 'logs_id',
-        'desc': 'Set a logs channel.'
+    "logs": {"datatype": "TextChannel", "dataname": "logs_id", "desc": "Set a logs channel."},
+    "mute": {"datatype": "Role", "dataname": "mute_id", "desc": "Set a mute role."},
+    "moderator": {
+        "datatype": "Role",
+        "dataname": "moderator_id",
+        "desc": "Set a moderator role.",
     },
-    'mute': {
-        'datatype': 'Role',
-        'dataname': 'mute_id',
-        'desc': 'Set a mute role.'
+    "helper": {"datatype": "Role", "dataname": "helper_id", "desc": "Set a helper role."},
+    "usermonitor": {
+        "datatype": "TextChannel",
+        "dataname": "monitor_user_log_id",
+        "desc": "Set a user monitoring log channel.",
     },
-    'moderator': {
-        'datatype': 'Role',
-        'dataname': 'moderator_id',
-        'desc': 'Set a moderator role.'
-    },
-    'helper': {
-        'datatype': 'Role',
-        'dataname': 'helper_id',
-        'desc': 'Set a helper role.'
-    },
-    'usermonitor': {
-        'datatype': 'TextChannel',
-        'dataname': 'monitor_user_log_id',
-        'desc': 'Set a user monitoring log channel.'
-    },
-    'messagemonitor': {
-        'datatype': 'TextChannel',
-        'dataname': 'monitor_message_log_id',
-        'desc': 'Set a message monitoring log channel.'
+    "messagemonitor": {
+        "datatype": "TextChannel",
+        "dataname": "monitor_message_log_id",
+        "desc": "Set a message monitoring log channel.",
     },
 }
 GUILD_CONFIGURATION_TOGGLES = {
-    'filtering': {
-        'datanames': ['filtering'],
-        'desc': 'Toggle filtering.'
+    "filtering": {"datanames": ["filtering"], "desc": "Toggle filtering."},
+    "usermonitor": {"datanames": ["monitoring_user"], "desc": "Toggle user monitoring."},
+    "messagemonitor": {
+        "datanames": ["monitoring_message"],
+        "desc": "Toggle message monitoring.",
     },
-    'usermonitor': {
-        'datanames': ['monitoring_user'],
-        'desc': 'Toggle user monitoring.'
-    },
-    'messagemonitor': {
-        'datanames': ['monitoring_message'],
-        'desc': 'Toggle message monitoring.'
-    },
-    'monitor': {
-        'datanames': ['monitoring_user', 'monitoring_message'],
-        'desc': 'Toggle monitoring.'
+    "monitor": {
+        "datanames": ["monitoring_user", "monitoring_message"],
+        "desc": "Toggle monitoring.",
     },
 }
 
 
-class GuildConfig(commands.Cog, name='Guild Settings'):
+class GuildConfig(commands.Cog, name="Guild Settings"):
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
 
@@ -105,7 +87,6 @@ class GuildConfig(commands.Cog, name='Guild Settings'):
             return guild_data.prefix
         return config.prefix
 
-
     @commands.command()
     async def guilddata(self, ctx: commands.Context):
         """
@@ -118,16 +99,22 @@ class GuildConfig(commands.Cog, name='Guild Settings'):
 
         data = ["**prefix**: " + (guild_data.prefix or config.prefix)]
         for name, field in GUILD_CONFIGURATION_DATA.items():
-            value = getattr(guild_data, field['dataname'])
-            output = f"**{name}**: " + (f"<{MENTION_STYLES[field['datatype']]}{value}> (ID: {value})" if value else "Not set.")
+            value = getattr(guild_data, field["dataname"])
+            output = f"**{name}**: " + (
+                f"<{MENTION_STYLES[field['datatype']]}{value}> (ID: {value})"
+                if value
+                else "Not set."
+            )
             data.append(output)
 
         toggles = {}
         for field in GUILD_CONFIGURATION_TOGGLES.values():
-            for name in field['datanames']:
+            for name in field["datanames"]:
                 if name in toggles:
                     continue
-                output = f"**{name}**: {'enabled' if getattr(guild_data, name) else 'disabled'}"
+                output = (
+                    f"**{name}**: {'enabled' if getattr(guild_data, name) else 'disabled'}"
+                )
                 toggles[name] = output
 
         embed = discord.Embed(
@@ -138,26 +125,31 @@ class GuildConfig(commands.Cog, name='Guild Settings'):
         embed.add_field(name="Toggles", value="\n".join(toggles.values()), inline=False)
         await ctx.send(embed=embed)
 
-
     @staticmethod
     def guild_data_set_factory(datatype: str, dataname: str, *, desc: Optional[str] = None):
         style = MENTION_STYLES[datatype]
         discord_type = getattr(discord, datatype)
+
         async def cmd(ctx: commands.Context, thing: Optional[discord_type] = None):
             f"""
             {desc}
             """
             values = {dataname: thing.id if thing else None}
-            guild_data, created = await GuildData.update_or_create(values, guild_id = ctx.guild.id)
+            guild_data, created = await GuildData.update_or_create(
+                values, guild_id=ctx.guild.id
+            )
             if created:
                 guild_data.prefix = config.prefix
                 await guild_data.save()
             get_guild_data.cache_clear()
 
             if thing:
-                await ctx.send(f'`{dataname}` set to <{style}{thing.id}> (ID: {thing.id}) for this guild.')
+                await ctx.send(
+                    f"`{dataname}` set to <{style}{thing.id}> (ID: {thing.id}) for this guild."
+                )
             else:
-                await ctx.send(f'`{dataname}` set to `None` for this guild.')
+                await ctx.send(f"`{dataname}` set to `None` for this guild.")
+
         return cmd
 
     @commands.group(invoke_without_command=True)
@@ -175,13 +167,12 @@ class GuildConfig(commands.Cog, name='Guild Settings'):
         """
         Set a custom bot prefix for this guild.
         """
-        values = {'prefix': prefix}
-        await GuildData.update_or_create(values, guild_id = ctx.guild.id)
+        values = {"prefix": prefix}
+        await GuildData.update_or_create(values, guild_id=ctx.guild.id)
         get_guild_data.cache_clear()
 
         prefix = prefix or config.prefix
-        await ctx.send(f'`prefix` set to `{prefix}` for this guild.')
-
+        await ctx.send(f"`prefix` set to `{prefix}` for this guild.")
 
     @staticmethod
     def guild_data_toggle_factory(datanames: list[str], desc: Optional[str] = None):
@@ -190,10 +181,19 @@ class GuildConfig(commands.Cog, name='Guild Settings'):
             {desc}
             """
             guild_data = await get_guild_data(guild_id=ctx.guild.id)
-            values = {dataname: not getattr(guild_data, dataname) if guild_data else True for dataname in datanames}
-            await GuildData.update_or_create(values, guild_id = ctx.guild.id)
+            values = {
+                dataname: not getattr(guild_data, dataname) if guild_data else True
+                for dataname in datanames
+            }
+            await GuildData.update_or_create(values, guild_id=ctx.guild.id)
             get_guild_data.cache_clear()
-            await ctx.send('\n'.join(f"`{dataname}` is {'`enabled`' if values[dataname] else '`disabled`'}" for dataname in datanames))
+            await ctx.send(
+                "\n".join(
+                    f"`{dataname}` is {'`enabled`' if values[dataname] else '`disabled`'}"
+                    for dataname in datanames
+                )
+            )
+
         return cmd
 
     @commands.group(invoke_without_command=True)

--- a/src/ib_py/config/config.py
+++ b/src/ib_py/config/config.py
@@ -7,15 +7,17 @@ from .reader import EnvReader, TomlReader
 
 class IBPyConfigError(Exception):
     """Custom exception for IBPyConfig errors."""
+
     pass
 
 
 class IBPyConfig:
     """Main configuration class for ib.py."""
+
     _instances = {}
 
     def __new__(cls, **kwargs):
-        """"
+        """ "
         Implements singleton-inspired pattern to ensure only one instance exists for each env/toml file pair.
         """
         env_file = kwargs.get("env_file", pathlib.Path(".env"))
@@ -26,18 +28,30 @@ class IBPyConfig:
             cls._instances[key] = instance
         return cls._instances[key]
 
-    def __init__(self, *, env_file: pathlib.Path = pathlib.Path(".env"), toml_file: pathlib.Path = pathlib.Path("config.toml")) -> None:
+    def __init__(
+        self,
+        *,
+        env_file: pathlib.Path = pathlib.Path(".env"),
+        toml_file: pathlib.Path = pathlib.Path("config.toml"),
+    ) -> None:
         if not env_file.exists():
-            warnings.warn(f"Environment file {env_file} does not exist. Proceeding without it.", UserWarning)
+            warnings.warn(
+                f"Environment file {env_file} does not exist. Proceeding without it.",
+                UserWarning,
+            )
         self.env_reader = EnvReader(env_file)
         try:
             self.toml_reader = TomlReader(toml_file)
         except FileNotFoundError as e:
-            parent = '.'.join(__name__.split('.')[:-1])  # get parent from package structure, needed for importlib.resources
-            with resources.path(parent, 'config.toml') as blank_toml_file:
-                with open(toml_file, 'w') as f_new, open(blank_toml_file, 'r') as f_blank:
+            parent = ".".join(
+                __name__.split(".")[:-1]
+            )  # get parent from package structure, needed for importlib.resources
+            with resources.path(parent, "config.toml") as blank_toml_file:
+                with open(toml_file, "w") as f_new, open(blank_toml_file, "r") as f_blank:
                     f_new.write(f_blank.read())
-            raise IBPyConfigError(f"TOML configuration file not found. A blank template has been created at {toml_file}. Please fill it out and restart the application.") from e
+            raise IBPyConfigError(
+                f"TOML configuration file not found. A blank template has been created at {toml_file}. Please fill it out and restart the application."
+            ) from e
 
     def __getattr__(self, name: str) -> str | None:
         """Get a configuration value from either the environment or the TOML file.
@@ -62,4 +76,6 @@ class IBPyConfig:
         """
         missing_keys = [key for key in keys if self.__getattr__(key) is None]
         if missing_keys:
-            raise IBPyConfigError(f"Missing required configuration keys: {', '.join(missing_keys)}")
+            raise IBPyConfigError(
+                f"Missing required configuration keys: {', '.join(missing_keys)}"
+            )

--- a/src/ib_py/db/cached.py
+++ b/src/ib_py/db/cached.py
@@ -11,6 +11,7 @@ from .models import (
 
 config = IBPyConfig()
 
+
 def cache(func):
     if getattr(config, "testing_env", False):
         func.cache_clear = lambda: None
@@ -22,6 +23,7 @@ def model_cache_factory(Model):
     @cache
     async def model_cache() -> list[Model]:
         return await Model.all()
+
     return model_cache
 
 

--- a/src/ib_py/utils/pagination.py
+++ b/src/ib_py/utils/pagination.py
@@ -58,9 +58,7 @@ def paginated_embed_menus(
         if "fields" in embed_dict:
             raise ValueError('embed_dict "fields" key must not be set.')
     else:
-        embed_dict = {  # default
-            "description": "Here is a list of entries."
-        }
+        embed_dict = {"description": "Here is a list of entries."}  # default
 
     if N == 0:
         embed_dict["description"] = empty_desc

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -27,9 +27,7 @@ class TestTagsCog(unittest.IsolatedAsyncioTestCase):
         await self.cog.tag_create(self, self.ctx, trigger=trigger, output=output)
 
         # Check DB update call
-        mock_update_or_create.assert_awaited_once_with(
-            {"output": output}, trigger=trigger
-        )
+        mock_update_or_create.assert_awaited_once_with({"output": output}, trigger=trigger)
 
         # Check cache cleared
         mock_cache_clear.assert_called_once()
@@ -100,9 +98,7 @@ class TestTagsCog(unittest.IsolatedAsyncioTestCase):
         # Assert
         mock_filter.assert_called_once_with(trigger=trigger)
         mock_cache_clear.assert_not_called()
-        self.ctx.send.assert_awaited_once_with(
-            f"Tag `{trigger}` does not exist."
-        )
+        self.ctx.send.assert_awaited_once_with(f"Tag `{trigger}` does not exist.")
 
     @patch("ib_py.cogs.tags.available_subcommands", new_callable=AsyncMock)
     async def test_tag_invokes_available_subcommands(self, mock_available_subcommands):
@@ -115,7 +111,9 @@ class TestTagsCog(unittest.IsolatedAsyncioTestCase):
     @patch("ib_py.cogs.tags.paginated_embed_menus")
     @patch("ib_py.cogs.tags.PaginationView")
     @patch("ib_py.cogs.tags.get_all_tags", new_callable=AsyncMock)
-    async def test_tag_list(self, mock_get_all_tags, mock_pagination_view, mock_paginated_embed_menus):
+    async def test_tag_list(
+        self, mock_get_all_tags, mock_pagination_view, mock_paginated_embed_menus
+    ):
         # Setup mocks for tags returned by get_all_tags
         mock_get_all_tags.return_value = [
             MagicMock(trigger="tag1", output="output1", disabled=False),
@@ -127,7 +125,9 @@ class TestTagsCog(unittest.IsolatedAsyncioTestCase):
 
         # Setup PaginationView mock instance with async method
         pagination_instance = MagicMock()
-        pagination_instance.return_paginated_embed_view = AsyncMock(return_value=("tag_embed", "tag_view"))
+        pagination_instance.return_paginated_embed_view = AsyncMock(
+            return_value=("tag_embed", "tag_view")
+        )
 
         # When PaginationView(...) is called, return the mock instance
         mock_pagination_view.return_value = pagination_instance
@@ -137,6 +137,7 @@ class TestTagsCog(unittest.IsolatedAsyncioTestCase):
 
         # Assert ctx.send called with correct embed and view
         self.ctx.send.assert_awaited_once_with(embed="tag_embed", view="tag_view")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -171,6 +171,45 @@ wheels = [
 ]
 
 [[package]]
+name = "black"
+version = "25.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "mypy-extensions" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+    { name = "pytokens" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/d9/07b458a3f1c525ac392b5edc6b191ff140b596f9d77092429417a54e249d/black-25.12.0.tar.gz", hash = "sha256:8d3dd9cea14bff7ddc0eb243c811cdb1a011ebb4800a5f0335a01a68654796a7", size = 659264, upload-time = "2025-12-08T01:40:52.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/ad/7ac0d0e1e0612788dbc48e62aef8a8e8feffac7eb3d787db4e43b8462fa8/black-25.12.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d0cfa263e85caea2cff57d8f917f9f51adae8e20b610e2b23de35b5b11ce691a", size = 1877003, upload-time = "2025-12-08T01:43:29.967Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/dd/a237e9f565f3617a88b49284b59cbca2a4f56ebe68676c1aad0ce36a54a7/black-25.12.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1a2f578ae20c19c50a382286ba78bfbeafdf788579b053d8e4980afb079ab9be", size = 1712639, upload-time = "2025-12-08T01:52:46.756Z" },
+    { url = "https://files.pythonhosted.org/packages/12/80/e187079df1ea4c12a0c63282ddd8b81d5107db6d642f7d7b75a6bcd6fc21/black-25.12.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3e1b65634b0e471d07ff86ec338819e2ef860689859ef4501ab7ac290431f9b", size = 1758143, upload-time = "2025-12-08T01:45:29.137Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b5/3096ccee4f29dc2c3aac57274326c4d2d929a77e629f695f544e159bfae4/black-25.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:a3fa71e3b8dd9f7c6ac4d818345237dfb4175ed3bf37cd5a581dbc4c034f1ec5", size = 1420698, upload-time = "2025-12-08T01:45:53.379Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/39/f81c0ffbc25ffbe61c7d0385bf277e62ffc3e52f5ee668d7369d9854fadf/black-25.12.0-cp311-cp311-win_arm64.whl", hash = "sha256:51e267458f7e650afed8445dc7edb3187143003d52a1b710c7321aef22aa9655", size = 1229317, upload-time = "2025-12-08T01:46:35.606Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/bd/26083f805115db17fda9877b3c7321d08c647df39d0df4c4ca8f8450593e/black-25.12.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:31f96b7c98c1ddaeb07dc0f56c652e25bdedaac76d5b68a059d998b57c55594a", size = 1924178, upload-time = "2025-12-08T01:49:51.048Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6b/ea00d6651561e2bdd9231c4177f4f2ae19cc13a0b0574f47602a7519b6ca/black-25.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:05dd459a19e218078a1f98178c13f861fe6a9a5f88fc969ca4d9b49eb1809783", size = 1742643, upload-time = "2025-12-08T01:49:59.09Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f3/360fa4182e36e9875fabcf3a9717db9d27a8d11870f21cff97725c54f35b/black-25.12.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1f68c5eff61f226934be6b5b80296cf6939e5d2f0c2f7d543ea08b204bfaf59", size = 1800158, upload-time = "2025-12-08T01:44:27.301Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/08/2c64830cb6616278067e040acca21d4f79727b23077633953081c9445d61/black-25.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:274f940c147ddab4442d316b27f9e332ca586d39c85ecf59ebdea82cc9ee8892", size = 1426197, upload-time = "2025-12-08T01:45:51.198Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/60/a93f55fd9b9816b7432cf6842f0e3000fdd5b7869492a04b9011a133ee37/black-25.12.0-cp312-cp312-win_arm64.whl", hash = "sha256:169506ba91ef21e2e0591563deda7f00030cb466e747c4b09cb0a9dae5db2f43", size = 1237266, upload-time = "2025-12-08T01:45:10.556Z" },
+    { url = "https://files.pythonhosted.org/packages/68/11/21331aed19145a952ad28fca2756a1433ee9308079bd03bd898e903a2e53/black-25.12.0-py3-none-any.whl", hash = "sha256:48ceb36c16dbc84062740049eef990bb2ce07598272e673c17d1a7720c71c828", size = 206191, upload-time = "2025-12-08T01:40:50.963Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -256,6 +295,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "black" },
     { name = "isort" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -274,6 +314,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "black", specifier = ">=25.12.0" },
     { name = "isort", specifier = ">=7.0.0" },
     { name = "pytest", specifier = ">=9.0.0" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
@@ -362,12 +403,39 @@ wheels = [
 ]
 
 [[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/86/0248f086a84f01b37aaec0fa567b397df1a119f73c16f6c7a9aac73ea309/platformdirs-4.5.1.tar.gz", hash = "sha256:61d5cdcc6065745cdd94f0f878977f8de9437be93de97c1c12f853c9c0cdcbda", size = 21715, upload-time = "2025-12-05T13:52:58.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/28/3bfe2fa5a7b9c46fe7e13c97bda14c895fb10fa2ebf1d0abb90e0cea7ee1/platformdirs-4.5.1-py3-none-any.whl", hash = "sha256:d03afa3963c806a9bed9d5125c8f4cb2fdaf74a55ab60e5d59b3fde758104d31", size = 18731, upload-time = "2025-12-05T13:52:56.823Z" },
 ]
 
 [[package]]
@@ -472,6 +540,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+]
+
+[[package]]
+name = "pytokens"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8d/a762be14dae1c3bf280202ba3172020b2b0b4c537f94427435f19c413b72/pytokens-0.3.0.tar.gz", hash = "sha256:2f932b14ed08de5fcf0b391ace2642f858f1394c0857202959000b68ed7a458a", size = 17644, upload-time = "2025-11-05T13:36:35.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/25/d9db8be44e205a124f6c98bc0324b2bb149b7431c53877fc6d1038dddaf5/pytokens-0.3.0-py3-none-any.whl", hash = "sha256:95b2b5eaf832e469d141a378872480ede3f251a5a5041b8ec6e581d3ac71bbf3", size = 12195, upload-time = "2025-11-05T13:36:33.183Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add black's autoformatting to the codebase as well as the codestyle checks on GitHub Actions.
Also configure pre-commit for the codebase to use the same checks (isort, black, ruff) as well as some other usual ones.

To use pre-commit, see the [installation instructions](https://pre-commit.com/#install) and run `pre-commit install` in the root directory.

Minor changes include bumping versions of actions used in the codestyle action.